### PR TITLE
Fix validationType destructuring bug

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -27,7 +27,7 @@ function readActionArguments(action, settings) {
       settingsValues[paramDefinition.name],
     );
 
-    const validationType = { paramDefinition };
+    const { validationType } = paramDefinition;
     if (validationType) {
       validateParamValue(
         paramValues[paramDefinition.name],


### PR DESCRIPTION
Instead of `const { validationType } = paramDefinition` there was `const validationType = { paramDefinition }`