### PR TITLE
Release v2.3.0

### DIFF
--- a/core.js
+++ b/core.js
@@ -10,6 +10,7 @@ function generatePluginMethod(method) {
     const methodDefinition = loadMethodFromConfiguration(action.method.name);
     const parameters = await helpers.readActionArguments(action, settings, methodDefinition);
 
+    const allowEmptyResult = methodDefinition.allowEmptyResult ?? false;
     const shouldRedactSecrets = methodDefinition.redactSecrets ?? consts.DEFAULT_REDACT_SECRETS;
     const secrets = shouldRedactSecrets
       && Object.values(await redaction.getVaultedParameters(parameters, methodDefinition));
@@ -25,7 +26,7 @@ function generatePluginMethod(method) {
       throw shouldRedactSecrets ? redaction.redactSecrets(error, secrets) : error;
     }
 
-    if (_.isNil(result) || _.isEmpty(result)) {
+    if (!allowEmptyResult && (_.isNil(result) || _.isEmpty(result))) {
       return consts.OPERATION_FINISHED_SUCCESSFULLY_MESSAGE;
     }
 

--- a/core.js
+++ b/core.js
@@ -1,19 +1,31 @@
 const _ = require("lodash");
+
 const consts = require("./consts.json");
 const helpers = require("./helpers");
 const redaction = require("./secrets-redaction");
 const autocomplete = require("./autocomplete");
-const { loadMethodFromConfiguration } = require("./config-loader");
+const {
+  loadMethodFromConfiguration,
+  loadConfiguration,
+} = require("./config-loader");
 
 function generatePluginMethod(method) {
   return async (action, settings) => {
     const methodDefinition = loadMethodFromConfiguration(action.method.name);
+    const pluginDefinition = loadConfiguration();
     const parameters = await helpers.readActionArguments(action, settings, methodDefinition);
 
     const allowEmptyResult = methodDefinition.allowEmptyResult ?? false;
     const shouldRedactSecrets = methodDefinition.redactSecrets ?? consts.DEFAULT_REDACT_SECRETS;
-    const secrets = shouldRedactSecrets
-      && Object.values(await redaction.getVaultedParameters(parameters, methodDefinition));
+    const secrets = [];
+    if (shouldRedactSecrets) {
+      const paramsDefinition = [
+        ...(methodDefinition.params ?? []),
+        ...(pluginDefinition.auth?.params ?? []),
+      ];
+      const secretsObject = redaction.filterVaultedParameters(parameters, paramsDefinition);
+      secrets.push(...Object.values(secretsObject));
+    }
 
     const utils = {
       logger: shouldRedactSecrets ? redaction.createRedactedLogger(secrets) : console,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kaholo/plugin-library",
-  "version": "2.1.2",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kaholo/plugin-library",
-      "version": "2.1.2",
+      "version": "2.3.0",
       "license": "ISC",
       "dependencies": {
         "fast-password-entropy": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaholo/plugin-library",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "Kaholo library for plugins",
   "main": "kaholo-plugin-library.js",
   "scripts": {

--- a/secrets-redaction.js
+++ b/secrets-redaction.js
@@ -81,8 +81,8 @@ function redactSecretsInPlainObject(input, secrets) {
   );
 }
 
-async function getVaultedParameters(params, methodDefinition) {
-  const vaultParams = Object.entries(params).filter(([paramName]) => methodDefinition.params.some(
+function filterVaultedParameters(params, paramsDefinition) {
+  const vaultParams = Object.entries(params).filter(([paramName]) => paramsDefinition.some(
     (paramDefinition) => paramDefinition.type === "vault" && paramDefinition.name === paramName,
   ));
   return Object.fromEntries(vaultParams);
@@ -93,7 +93,7 @@ function escapeRegExp(string) {
 }
 
 module.exports = {
-  getVaultedParameters,
+  filterVaultedParameters,
   redactSecrets,
   createRedactedLogger,
 };


### PR DESCRIPTION
Fixed:
* [**KP-1153**](https://kaholo.atlassian.net/browse/KP-1153) Secrets redaction (Account's vault params were not redacted)

Added:
* [**KP-1165**](https://kaholo.atlassian.net/browse/KP-1165) Support for `allowEmptyResult` configuration field