### PR TITLE
Release v2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kaholo/plugin-library",
-  "version": "2.1.2",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kaholo/plugin-library",
-      "version": "2.1.2",
+      "version": "2.3.0",
       "license": "ISC",
       "dependencies": {
         "fast-password-entropy": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaholo/plugin-library",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "Kaholo library for plugins",
   "main": "kaholo-plugin-library.js",
   "scripts": {


### PR DESCRIPTION
Fixed:
* [**KP-1153**](https://kaholo.atlassian.net/browse/KP-1153) Secrets redaction (Account's vault params were not redacted)

Added:
* [**KP-1165**](https://kaholo.atlassian.net/browse/KP-1165) Support for `allowEmptyResult` configuration field